### PR TITLE
feat: add version to string through seperate class

### DIFF
--- a/Main/forgeutils.lua
+++ b/Main/forgeutils.lua
@@ -1,5 +1,6 @@
 ---This is a simple namespace for forgeutils.
 ---Contains the version of the mod.
+local version = require("forgeutils.modversion")
 
 ---@class forgeutils.Version Semantic versioning type.
 ---@field major integer? The major (breaking change) number.
@@ -13,10 +14,10 @@ local ForgeUtils = {}
 -- Note: Do not change the indentation.
 -- This is modified and read by pipelines.
 -- Modify data in place.
-ForgeUtils.version = {
+ForgeUtils.version = version.new({
     major = 2,
     minor = 0,
-    patch = 0,
-}
+    patch = 0
+})
 
 return ForgeUtils

--- a/Main/forgeutils.lua
+++ b/Main/forgeutils.lua
@@ -2,13 +2,8 @@
 ---Contains the version of the mod.
 local version = require("forgeutils.modversion")
 
----@class forgeutils.Version Semantic versioning type.
----@field major integer? The major (breaking change) number.
----@field minor integer? The minor (new non-breaking addition) number.
----@field patch integer? The patch (non-breaking bug fix) number.
-
 ---@class forgeutils
----@field version forgeutils.Version The version of ForgeUtils.
+---@field version forgeutils.ModVersion The version of ForgeUtils.
 local ForgeUtils = {}
 
 -- Note: Do not change the indentation.

--- a/Main/forgeutils/modversion.lua
+++ b/Main/forgeutils/modversion.lua
@@ -1,0 +1,27 @@
+---@class forgeutils.modversion Semantic versioning type.
+---@field major integer? The major (breaking change) number.
+---@field minor integer? The minor (new non-breaking addition) number.
+---@field patch integer? The patch (non-breaking bug fix) number.
+local ModVersion = {}
+ModVersion.__index = ModVersion
+
+function ModVersion.new(args)
+    local self = setmetatable({}, ModVersion)
+    self.major = args.major
+    self.minor = args.minor
+    self.patch = args.patch
+    return self
+end
+
+function ModVersion:tostring()
+    return self.major .. "." .. self.minor .. "." .. self.patch
+end
+
+function ModVersion:iscompatable(v)
+    if v.major <= self.major and v.minor <= self.minor and v.patch <= self.patch then
+        return true
+    end
+    return false
+end
+
+return ModVersion


### PR DESCRIPTION
Adds new `modversion` class.

this does add a `modversion.tostring()` method. i do want to use metatables and instead create one for `tostring(modversion)` instead

`.new` does currently use a table as the parsing arguments. unsure if i want to move that to a `.parse` instead.